### PR TITLE
feat: add image for generated collections

### DIFF
--- a/Jellyfin.Plugin.CollectionImport/CollectionImportManager.cs
+++ b/Jellyfin.Plugin.CollectionImport/CollectionImportManager.cs
@@ -162,6 +162,7 @@ public class CollectionImportManager
             return;
         }
         var collection = GetBoxSetByName(set.Name);
+        var created = false;
         if (collection is null)
         {
             _logger.LogInformation("{Name} not found, creating.", set.Name);
@@ -172,6 +173,7 @@ public class CollectionImportManager
             });
             collection.Tags = new[] { "collectionimport" };
             collection.DisplayOrder = "Default";
+            created = true;
         }
 
         collection.DisplayOrder = "Default";
@@ -183,7 +185,9 @@ public class CollectionImportManager
         await _collectionManager.RemoveFromCollectionAsync(collection.Id, children.Select(i => i.Id)).ConfigureAwait(true);
 
         await _collectionManager.AddToCollectionAsync(collection.Id, ids).ConfigureAwait(true);
-        await SetPhotoForCollection(collection);
+        if (created) {
+            await SetPhotoForCollection(collection);
+        }
     }
 
     public async Task SyncPlaylist(ImportSet set, IEnumerable<BaseItem> dbItems, CancellationToken cancellationToken)

--- a/Jellyfin.Plugin.CollectionImport/CollectionImportManager.cs
+++ b/Jellyfin.Plugin.CollectionImport/CollectionImportManager.cs
@@ -27,6 +27,7 @@ using Jellyfin.Plugin.CollectionImport.Configuration;
 using System.Security.Cryptography.X509Certificates;
 using MediaBrowser.Controller.Playlists;
 using MediaBrowser.Model.Playlists;
+using MediaBrowser.Controller.Entities.TV;
 
 namespace Jellyfin.Plugin.CollectionImport;
 
@@ -96,7 +97,63 @@ public class CollectionImportManager
         }
         return Interleave(idSets);
     }
-    
+
+    private async Task SetPhotoForCollection(BoxSet collection)
+    {
+        try
+        {
+            var query = new InternalItemsQuery
+            {
+                Recursive = true
+            };
+
+            var items = collection.GetItems(query)
+                .Items
+                .Where(item => item is Movie || item is Series)
+                .ToList();
+
+            _logger.LogDebug("Found {Count} items in collection {CollectionName}",
+                items.Count, collection.Name);
+
+            var firstItemWithImage = items
+                .FirstOrDefault(item =>
+                    item.ImageInfos != null &&
+                    item.ImageInfos.Any(i => i.Type == ImageType.Primary));
+
+            if (firstItemWithImage != null)
+            {
+                var imageInfo = firstItemWithImage.ImageInfos
+                    .First(i => i.Type == ImageType.Primary);
+
+                // Simply set the image path directly
+                collection.SetImage(new ItemImageInfo
+                {
+                    Path = imageInfo.Path,
+                    Type = ImageType.Primary
+                }, 0);
+
+                await _libraryManager.UpdateItemAsync(
+                    collection,
+                    collection.GetParent(),
+                    ItemUpdateType.ImageUpdate,
+                    CancellationToken.None);
+                _logger.LogInformation("Successfully set image for collection {CollectionName} from {ItemName}",
+                    collection.Name, firstItemWithImage.Name);
+            }
+            else
+            {
+                _logger.LogWarning("No items with images found in collection {CollectionName}. Items: {Items}",
+                    collection.Name,
+                    string.Join(", ", items.Select(i => i.Name)));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error setting image for collection {CollectionName}",
+                collection.Name);
+        }
+    }
+
     public async Task SyncCollection(ImportSet set, IEnumerable<BaseItem> dbItems, CancellationToken cancellationToken)
     {
         _logger.LogInformation("Syncing {Name}", set.Name);
@@ -118,7 +175,7 @@ public class CollectionImportManager
         }
 
         collection.DisplayOrder = "Default";
-        
+
         var ids = await GetItemIdsFromMdb(set, dbItems);
 
         // we need to clear it first, otherwise sorting is not applied.
@@ -126,6 +183,7 @@ public class CollectionImportManager
         await _collectionManager.RemoveFromCollectionAsync(collection.Id, children.Select(i => i.Id)).ConfigureAwait(true);
 
         await _collectionManager.AddToCollectionAsync(collection.Id, ids).ConfigureAwait(true);
+        await SetPhotoForCollection(collection);
     }
 
     public async Task SyncPlaylist(ImportSet set, IEnumerable<BaseItem> dbItems, CancellationToken cancellationToken)
@@ -210,7 +268,7 @@ public class CollectionImportManager
             Name = name,
         }).Select(b => b as BoxSet).FirstOrDefault();
     }
-    
+
     public Playlist? GetPlaylistByName(string name)
     {
         return _playlistManager.GetPlaylists(_adminUser.Id)


### PR DESCRIPTION
Right now, collections generated by jellyfin-plugin-collection-import do not have any image associated with them, so they look a bit strange in the collections view, almost like they're incomplete by default.

This PR uses an image from one of the movies/shows in the collection if available as the image to associate with the collection.

In some ways this is cool, as the poster might update over time as the trending movies change.

But in other ways this is not cool, because you might want to set a custom image for your Trending collection that you don't want overwritten.

What do you think? I personally can't see myself setting a custom image for my imported collections, and I prefer the dynamic approach in this PR to the empty state I'd have otherwise.